### PR TITLE
- LogExceptionsAzureTableStorageDecorator was added

### DIFF
--- a/src/Lykke.AzureStorage.Test/AzureTableStorageTest.cs
+++ b/src/Lykke.AzureStorage.Test/AzureTableStorageTest.cs
@@ -2,11 +2,10 @@ using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using AzureStorage.Tables;
 using Microsoft.WindowsAzure.Storage.Table;
-using Microsoft.WindowsAzure.Storage;
-using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
-using System.IO;
 using System.Threading.Tasks;
+using AzureStorage;
+using Lykke.AzureStorage.Test.Mocks;
 
 namespace Lykke.AzureStorage.Test
 {
@@ -19,7 +18,7 @@ namespace Lykke.AzureStorage.Test
     public class AzureTableStorageTest
     {
         private readonly string _azureStorageConnectionString;
-        private AzureTableStorage<TestEntity> _testEntityStorage;
+        private INoSQLTableStorage<TestEntity> _testEntityStorage;
         private string _tableName = "LykkeAzureStorageTest";
 
         //AzureStorage - azure account
@@ -35,7 +34,10 @@ namespace Lykke.AzureStorage.Test
         [TestInitialize]
         public void TestInit()
         {
-            _testEntityStorage = new AzureTableStorage<TestEntity>(_azureStorageConnectionString, _tableName, null);
+            _testEntityStorage = AzureTableStorage<TestEntity>.Create(
+                new ConnStringReloadingManagerMock(_azureStorageConnectionString), 
+                _tableName, 
+                null);
         }
 
         [TestCleanup]
@@ -61,7 +63,10 @@ namespace Lykke.AzureStorage.Test
         {
             var testEntity = GetTestEntity();
 
-            var storage1 = new AzureTableStorage<TestEntity>(_azureStorageConnectionString, _tableName, null);
+            var storage1 = AzureTableStorage<TestEntity>.Create(
+                new ConnStringReloadingManagerMock(_azureStorageConnectionString),
+                _tableName,
+                null);
 
             Parallel.For(1, 10, i =>
             {
@@ -90,7 +95,10 @@ namespace Lykke.AzureStorage.Test
         {
             var testEntity = GetTestEntity();
 
-            var storage1 = new AzureTableStorageWithCache<TestEntity>(_azureStorageConnectionString, _tableName, null);
+            var storage1 = AzureTableStorage<TestEntity>.CreateWithCache(
+                new ConnStringReloadingManagerMock(_azureStorageConnectionString), 
+                _tableName,
+                null);
 
             Parallel.For(1, 10, i =>
             {

--- a/src/Lykke.AzureStorage.Test/Mocks/ConnStringReloadingManagerMock.cs
+++ b/src/Lykke.AzureStorage.Test/Mocks/ConnStringReloadingManagerMock.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Lykke.SettingsReader;
+
+namespace Lykke.AzureStorage.Test.Mocks
+{
+    internal class ConnStringReloadingManagerMock : IReloadingManager<string>
+    {
+        public bool HasLoaded => true;
+        public string CurrentValue => _connectionString;
+
+        private readonly string _connectionString;
+
+        public ConnStringReloadingManagerMock(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public Task<string> Reload()
+        {
+            return Task.FromResult(_connectionString);
+        }
+    }
+}

--- a/src/Lykke.AzureStorage/AzureStorageUtils.cs
+++ b/src/Lykke.AzureStorage/AzureStorageUtils.cs
@@ -45,21 +45,6 @@ namespace AzureStorage
             return notLogCodes.Any(notLogCode => storageException.RequestInformation.HttpStatusCode == notLogCode);
         }
 
-        public static string PrintItems(IEnumerable<object> items)
-        {
-            var sb = new StringBuilder();
-
-            if (items != null && items.Any())
-            {
-                foreach (var item in items)
-                {
-                    sb.Append(PrintItem(item));
-                }
-            }
-
-            return sb.ToString();
-        }
-
         public static string PrintItem(object item)
         {
             if (item is string)
@@ -700,5 +685,5 @@ namespace AzureStorage
 
 			return tasks[0].Result;
 		}
-	}
+    }
 }

--- a/src/Lykke.AzureStorage/Blob/AzureBlobInMemory.cs
+++ b/src/Lykke.AzureStorage/Blob/AzureBlobInMemory.cs
@@ -150,14 +150,14 @@ namespace AzureStorage.Blob
             return Task.FromResult(false);
         }
 
-        public async Task<string> GetMetadataAsync(string container, string key, string metaDataKey)
+        public Task<string> GetMetadataAsync(string container, string key, string metaDataKey)
         {
-            return null;
+            return Task.FromResult<string>(null);
         }
 
-        public async Task<IDictionary<string, string>> GetMetadataAsync(string container, string key)
+        public Task<IDictionary<string, string>> GetMetadataAsync(string container, string key)
         {
-            return new Dictionary<string, string>();
+            return Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>());
         }
     }
 }

--- a/src/Lykke.AzureStorage/Blob/AzureBlobLocal.cs
+++ b/src/Lykke.AzureStorage/Blob/AzureBlobLocal.cs
@@ -141,14 +141,14 @@ namespace AzureStorage.Blob
             throw new NotImplementedException();
         }
 
-        public async Task<string> GetMetadataAsync(string container, string key, string metaDataKey)
+        public Task<string> GetMetadataAsync(string container, string key, string metaDataKey)
         {
-            return null;
+            return Task.FromResult<string>(null);
         }
 
-        public async Task<IDictionary<string, string>> GetMetadataAsync(string container, string key)
+        public Task<IDictionary<string, string>> GetMetadataAsync(string container, string key)
         {
-            return new Dictionary<string, string>();
+            return Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>());
         }
     }
 }

--- a/src/Lykke.AzureStorage/INoSqlTableStorage.cs
+++ b/src/Lykke.AzureStorage/INoSqlTableStorage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AzureStorage.Tables;
 using Microsoft.WindowsAzure.Storage.Table;
 
 namespace AzureStorage
@@ -8,131 +9,224 @@ namespace AzureStorage
     public interface INoSQLTableStorage<T> : IEnumerable<T> where T : ITableEntity, new()
     {
         /// <summary>
-        ///     Возвращает элемент
+        /// Storage name
         /// </summary>
-        /// <param name="partition">Партиция</param>
-        /// <param name="row">Колонка</param>
-        /// <returns>null или объект</returns>
+        string Name { get; }
+
+        /// <summary>
+        /// Queries a row.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
+        /// <param name="partition">Partition</param>
+        /// <param name="row">Row</param>
+        /// <returns>null or row item</returns>
         T this[string partition, string row] { get; }
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         IEnumerable<T> this[string partition] { get; }
 
         /// <summary>
-        ///     Добавить новый элемент в таблице
+        /// Add new row to the table.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
         /// </summary>
-        /// <param name="item">Элемент, который нужно вставить</param>
-        /// <param name="notLogCodes">не логировать эксепшены с кодами согласно списку</param>
+        /// <param name="item">Row item to insert</param>
+        /// <param name="notLogCodes">Azure table storage exceptions codes, which are should not be logged</param>
         Task InsertAsync(T item, params int[] notLogCodes);
 
+        /// <summary>
+        /// Add new row to the table.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task InsertAsync(IEnumerable<T> items);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task InsertOrMergeAsync(T item);
-        Task InsertOrMergeBatchAsync(IEnumerable<T> items);
-
-        Task<T> ReplaceAsync(string partitionKey, string rowKey, Func<T, T> item);
-
-        Task<T> MergeAsync(string partitionKey, string rowKey, Func<T, T> item);
-
-        Task InsertOrReplaceBatchAsync(IEnumerable<T> entities);
-
 
         /// <summary>
-        ///     Добавляет новый элемент, или заменяет полностью существующий
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
         /// </summary>
-        /// <param name="item"></param>
+        Task InsertOrMergeBatchAsync(IEnumerable<T> items);
+
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
+        Task<T> ReplaceAsync(string partitionKey, string rowKey, Func<T, T> item);
+
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
+        Task<T> MergeAsync(string partitionKey, string rowKey, Func<T, T> item);
+
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
+        Task InsertOrReplaceBatchAsync(IEnumerable<T> entities);
+
+        /// <summary>
+        /// Adds or entirely replaces row.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task InsertOrReplaceAsync(T item);
 
+        /// <summary>
+        /// Adds or entirely replaces row.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task InsertOrReplaceAsync(IEnumerable<T> items);
 
         /// <summary>
-        ///     Удаляет элемент из таблицы
+        /// Deletes row from the table.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
         /// </summary>
-        /// <param name="item"></param>
         Task DeleteAsync(T item);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<T> DeleteAsync(string partitionKey, string rowKey);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<bool> DeleteIfExistAsync(string partitionKey, string rowKey);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task DeleteAsync(IEnumerable<T> items);
 
         /// <summary>
-        /// Creates record if not existed before
+        /// Creates record if not existed before.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
         /// </summary>
-        /// <param name="item"></param>
         /// <returns>true if created, false if existed before</returns>
         Task<bool> CreateIfNotExistsAsync(T item);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         bool RecordExists(T item);
 
-       
-
-
-        Task<T> GetDataAsync(string partition, string row);
-
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
+        Task<bool> RecordExistsAsync(T item);
 
         /// <summary>
-        ///     Получить записи, предварительно отфильтровав их
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
         /// </summary>
-        /// <param name="filter"></param>
-        /// <returns></returns>
+        Task<T> GetDataAsync(string partition, string row);
+
+        /// <summary>
+        /// Queries data with client-side filtering.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<IList<T>> GetDataAsync(Func<T, bool> filter = null);
 
         /// <summary>
-        ///     Запрос по одной партиции и нескольким элементам
+        /// Queries multiple rows of single partition.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
         /// </summary>
-        /// <param name="partitionKey"></param>
-        /// <param name="rowKeys"></param>
-        /// <param name="pieceSize">На сколько частейделим запрос</param>
-        /// <param name="filter">Фильтрация записей</param>
-        /// <returns></returns>
+        /// <param name="partitionKey">Partition key</param>
+        /// <param name="rowKeys">Row keys</param>
+        /// <param name="pieceSize">Chank size</param>
+        /// <param name="filter">Rows filter</param>
         Task<IEnumerable<T>> GetDataAsync(string partitionKey, IEnumerable<string> rowKeys, int pieceSize = 100,
             Func<T, bool> filter = null);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<IEnumerable<T>> GetDataAsync(IEnumerable<string> partitionKeys, int pieceSize = 100,
             Func<T, bool> filter = null);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<IEnumerable<T>> GetDataAsync(IEnumerable<Tuple<string, string>> keys, int pieceSize = 100,
             Func<T, bool> filter = null);
-
-
+        
+        /// <summary>
+        /// Not auto-retried, if <see cref="AzureTableStorage{T}"/> implementation is used, since this is not atomic operation
+        /// </summary>
         Task GetDataByChunksAsync(Func<IEnumerable<T>, Task> chunks);
 
+        /// <summary>
+        /// Not auto-retried, if <see cref="AzureTableStorage{T}"/> implementation is used, since this is not atomic operation
+        /// </summary>
         Task GetDataByChunksAsync(Action<IEnumerable<T>> chunks);
+
+        /// <summary>
+        /// Not auto-retried, if <see cref="AzureTableStorage{T}"/> implementation is used, since this is not atomic operation
+        /// </summary>
         Task GetDataByChunksAsync(string partitionKey, Action<IEnumerable<T>> chunks);
 
+        /// <summary>
+        /// Not auto-retried, if <see cref="AzureTableStorage{T}"/> implementation is used, since this is not atomic operation
+        /// </summary>
         Task ScanDataAsync(string partitionKey, Func<IEnumerable<T>, Task> chunk);
+        
+        /// <summary>
+        /// Not auto-retried, if <see cref="AzureTableStorage{T}"/> implementation is used, since this is not atomic operation
+        /// </summary>
         Task ScanDataAsync(TableQuery<T> rangeQuery, Func<IEnumerable<T>, Task> chunk);
 
         /// <summary>
-        ///     Scan table by chinks and find an instane
+        /// Scan table by chinks and find an instane.
+        /// Not auto-retried, if <see cref="AzureTableStorage{T}"/> implementation is used, since this is not atomic operation
         /// </summary>
         /// <param name="partitionKey">Partition we are going to scan</param>
         /// <param name="dataToSearch">CallBack, which we going to call when we have chunk of data to scan. </param>
         /// <returns>Null or instance</returns>
         Task<T> FirstOrNullViaScanAsync(string partitionKey, Func<IEnumerable<T>, T> dataToSearch);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<IEnumerable<T>> GetDataAsync(string partition, Func<T, bool> filter = null);
+
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<T> GetTopRecordAsync(string partition);
+
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<IEnumerable<T>> GetTopRecordsAsync(string partition, int n);
 
+        /// <summary>
+        /// Not auto-retried, if <see cref="AzureTableStorage{T}"/> implementation is used, since this is not atomic operation
+        /// </summary>
         Task<IEnumerable<T>> GetDataRowKeysOnlyAsync(IEnumerable<string> rowKeys);
 
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<IEnumerable<T>> WhereAsyncc(TableQuery<T> rangeQuery, Func<T, Task<bool>> filter = null);
+
+        /// <summary>
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
         Task<IEnumerable<T>> WhereAsync(TableQuery<T> rangeQuery, Func<T, bool> filter = null);
 
         /// <summary>
-        ///     Асинхронное получение данных. Можно использовать для экономии памяти запроса.
+        /// Recieves data asynchronously. Could be used for memory saving
+        /// Not auto-retried, if <see cref="AzureTableStorage{T}"/> implementation is used, since this is not atomic operation
         /// </summary>
-        /// <param name="rangeQuery">Запрос</param>
-        /// <param name="yieldResult">обратные вызовы кусками с информацией, полученной по сети</param>
+        /// <param name="rangeQuery">Query</param>
+        /// <param name="yieldResult">Data chank processing delegate</param>
         /// <param name="stopCondition">Stop condition func</param>
-        /// <returns>Task</returns>
-        Task ExecuteAsync(TableQuery<T> rangeQuery, Action<IEnumerable<T>> yieldResult, Func<bool> stopCondition = null);	
-		/// <summary>
-		///     Выполнить набор операций
-		/// </summary>
-		/// <param name="batch"></param>
-		Task DoBatchAsync(TableBatchOperation batch);
-	}
+        Task ExecuteAsync(TableQuery<T> rangeQuery, Action<IEnumerable<T>> yieldResult, Func<bool> stopCondition = null);
+
+        /// <summary>
+        /// Executes batch of operations.
+        /// Auto retries, if <see cref="AzureTableStorage{T}"/> implementation is used
+        /// </summary>
+        Task DoBatchAsync(TableBatchOperation batch);
+    }
 }

--- a/src/Lykke.AzureStorage/Tables/AzureTableStorage.cs
+++ b/src/Lykke.AzureStorage/Tables/AzureTableStorage.cs
@@ -35,7 +35,7 @@ namespace AzureStorage.Tables
             _tableName = tableName;
             _cloudStorageAccount = CloudStorageAccount.Parse(connectionString);
 
-            _maxExecutionTime = maxExecutionTimeout.GetValueOrDefault(TimeSpan.FromSeconds(30));
+            _maxExecutionTime = maxExecutionTimeout.GetValueOrDefault(TimeSpan.FromSeconds(5));
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace AzureStorage.Tables
         /// <param name="connectionStringManager">Connection string reloading manager</param>
         /// <param name="tableName">Table's name</param>
         /// <param name="log">Log</param>
-        /// <param name="maxExecutionTimeout">Maximum execution time of single request (within retries). Default is 30 seconds</param>
+        /// <param name="maxExecutionTimeout">Maximum execution time of single request (within retries). Default is 5 seconds</param>
         /// <param name="onModificationRetryCount">Retries count when performs modification operation. Default value is 10</param>
         /// <param name="onGettingRetryCount">Retries count when performs reading operation. Default value is 10</param>
         /// <param name="retryDelay">Delay between retries. Default is 200 milliseconds</param>
@@ -93,7 +93,7 @@ namespace AzureStorage.Tables
         /// <param name="connectionStringManager">Connection string reloading manager</param>
         /// <param name="tableName">Table's name</param>
         /// <param name="log">Log</param>
-        /// <param name="maxExecutionTimeout">Maximum execution time of single request (within retries). Default is 30 seconds</param>
+        /// <param name="maxExecutionTimeout">Maximum execution time of single request (within retries). Default is 5 seconds</param>
         /// <param name="onModificationRetryCount">Retries count when performs modification operation. Default value is 10</param>
         /// <param name="onGettingRetryCount">Retries count when performs reading operation. Default value is 10</param>
         /// <param name="retryDelay">Delay between retries. Default is 200 milliseconds</param>

--- a/src/Lykke.AzureStorage/Tables/AzureTableStorage.cs
+++ b/src/Lykke.AzureStorage/Tables/AzureTableStorage.cs
@@ -10,7 +10,6 @@ using Common;
 using Common.Extensions;
 using Common.Log;
 
-using Lykke.AzureStorage;
 using Lykke.AzureStorage.Tables;
 using Lykke.SettingsReader;
 
@@ -23,31 +22,104 @@ namespace AzureStorage.Tables
     {
         public const int Conflict = 409;
 
-        private readonly TimeSpan _maxExecutionTime;
+        public string Name => _tableName;
 
-        private readonly ILog _log;
+        private readonly TimeSpan _maxExecutionTime;
         private readonly string _tableName;
 
         private readonly CloudStorageAccount _cloudStorageAccount;
         private bool _tableCreated;
 
-        [Obsolete("Have to use the AzureTableStorage.Create method to reloading ConnectionString on access failure.", false)]
-        public AzureTableStorage(string connectionString, string tableName, ILog log, TimeSpan? maxExecutionTimeout = null) 
+        private AzureTableStorage(string connectionString, string tableName, TimeSpan? maxExecutionTimeout = null) 
         {
             _tableName = tableName;
-            _log = log ?? EmptyLog.Instance;
             _cloudStorageAccount = CloudStorageAccount.Parse(connectionString);
 
             _maxExecutionTime = maxExecutionTimeout.GetValueOrDefault(TimeSpan.FromSeconds(30));
         }
 
-        public static INoSQLTableStorage<T> Create(IReloadingManager<string> connectionStringManager, string tableName, ILog log, TimeSpan? maxExecutionTimeout = null)
+        /// <summary>
+        /// Creates <see cref="AzureTableStorage{T}"/> with auto retries (only atomic operations) and connection string reloading.
+        /// </summary>
+        /// <remarks>
+        /// Not atomic methods without retries:
+        /// - GetDataByChunksAsync
+        /// - ScanDataAsync
+        /// - FirstOrNullViaScanAsync
+        /// - GetDataRowKeysOnlyAsync
+        /// - ExecuteAsync
+        /// </remarks>
+        /// <param name="connectionStringManager">Connection string reloading manager</param>
+        /// <param name="tableName">Table's name</param>
+        /// <param name="log">Log</param>
+        /// <param name="maxExecutionTimeout">Maximum execution time of single request (within retries). Default is 30 seconds</param>
+        /// <param name="onModificationRetryCount">Retries count when performs modification operation. Default value is 10</param>
+        /// <param name="onGettingRetryCount">Retries count when performs reading operation. Default value is 10</param>
+        /// <param name="retryDelay">Delay between retries. Default is 200 milliseconds</param>
+        /// <returns></returns>
+        public static INoSQLTableStorage<T> Create(
+            IReloadingManager<string> connectionStringManager,
+            string tableName,
+            ILog log,
+            TimeSpan? maxExecutionTimeout = null,
+            int onModificationRetryCount = 10,
+            int onGettingRetryCount = 10,
+            TimeSpan? retryDelay = null)
         {
-            return new ReloadingConnectionStringOnFailureAzureTableStorageDecorator<T>(
-#pragma warning disable 618
-                async () => new AzureTableStorage<T>(await connectionStringManager.Reload(), tableName, log, maxExecutionTimeout)
-#pragma warning restore 618
-            );
+            async Task<INoSQLTableStorage<T>> MakeStorage() 
+                => new AzureTableStorage<T>(await connectionStringManager.Reload(), tableName, maxExecutionTimeout);
+
+            return
+                new LogExceptionsAzureTableStorageDecorator<T>(
+                    new RetryOnFailureAzureTableStorageDecorator<T>(
+                        new ReloadingConnectionStringOnFailureAzureTableStorageDecorator<T>(MakeStorage),
+                        onModificationRetryCount,
+                        onGettingRetryCount,
+                        retryDelay),
+                    log);
+        }
+
+        /// <summary>
+        /// Creates <see cref="AzureTableStorage{T}"/> with cache, auto retries (only atomic operations) and connection string reloading.
+        /// </summary>
+        /// <remarks>
+        /// Not atomic methods without retries:
+        /// - GetDataByChunksAsync
+        /// - ScanDataAsync
+        /// - FirstOrNullViaScanAsync
+        /// - GetDataRowKeysOnlyAsync
+        /// - ExecuteAsync
+        /// </remarks>
+        /// <param name="connectionStringManager">Connection string reloading manager</param>
+        /// <param name="tableName">Table's name</param>
+        /// <param name="log">Log</param>
+        /// <param name="maxExecutionTimeout">Maximum execution time of single request (within retries). Default is 30 seconds</param>
+        /// <param name="onModificationRetryCount">Retries count when performs modification operation. Default value is 10</param>
+        /// <param name="onGettingRetryCount">Retries count when performs reading operation. Default value is 10</param>
+        /// <param name="retryDelay">Delay between retries. Default is 200 milliseconds</param>
+        /// <returns></returns>
+        public static INoSQLTableStorage<T> CreateWithCache(
+            IReloadingManager<string> connectionStringManager,
+            string tableName,
+            ILog log,
+            TimeSpan? maxExecutionTimeout = null,
+            int onModificationRetryCount = 10,
+            int onGettingRetryCount = 10,
+            TimeSpan? retryDelay = null)
+        {
+            async Task<INoSQLTableStorage<T>> MakeStorage() 
+                => new AzureTableStorage<T>(await connectionStringManager.Reload(), tableName, maxExecutionTimeout);
+
+            return
+                new LogExceptionsAzureTableStorageDecorator<T>(
+                    new CachedAzureTableStorageDecorator<T>(
+                        new RetryOnFailureAzureTableStorageDecorator<T>(
+                            new ReloadingConnectionStringOnFailureAzureTableStorageDecorator<T>(MakeStorage),
+                            onModificationRetryCount,
+                            onGettingRetryCount,
+                            retryDelay)
+                    ),
+                    log);
         }
 
         private TableRequestOptions GetRequestOptions()
@@ -60,7 +132,7 @@ namespace AzureStorage.Tables
 
         public async Task DoBatchAsync(TableBatchOperation batch)
         {
-            var table = await GetTable();
+            var table = await GetTableAsync();
             await table.ExecuteLimitSafeBatchAsync(batch, GetRequestOptions(), null);
         }
 
@@ -76,187 +148,105 @@ namespace AzureStorage.Tables
 
         public virtual async Task InsertAsync(T item, params int[] notLogCodes)
         {
-            try
-            {
-                var table = await GetTable();
-                await table.ExecuteAsync(TableOperation.Insert(item), GetRequestOptions(), null);
-            }
-            catch (Exception ex)
-            {
-                await HandleException(item, ex, notLogCodes);
-                throw;
-            }
+            var table = await GetTableAsync();
+            await table.ExecuteAsync(TableOperation.Insert(item), GetRequestOptions(), null);
         }
 
         public async Task InsertAsync(IEnumerable<T> items)
         {
             items = items.ToArray();
-            try
+            
+            if (items.Any())
             {
-                if (items.Any())
-                {
-                    var insertBatchOperation = new TableBatchOperation();
-                    foreach (var item in items)
-                        insertBatchOperation.Insert(item);
-                    var table = await GetTable();
-                    await table.ExecuteLimitSafeBatchAsync(insertBatchOperation, GetRequestOptions(), null);
-                }
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(InsertAsync),
-                        AzureStorageUtils.PrintItems(items),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "InsertAsync batch", AzureStorageUtils.PrintItems(items), ex);
-                throw;
+                var insertBatchOperation = new TableBatchOperation();
+                foreach (var item in items)
+                    insertBatchOperation.Insert(item);
+                var table = await GetTableAsync();
+                await table.ExecuteLimitSafeBatchAsync(insertBatchOperation, GetRequestOptions(), null);
             }
         }
 
         public async Task InsertOrMergeAsync(T item)
         {
-            try
-            {
-                var table = await GetTable();
-                await table.ExecuteAsync(TableOperation.InsertOrMerge(item), GetRequestOptions(), null);
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(InsertOrMergeAsync),
-                        AzureStorageUtils.PrintItem(item),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "InsertOrMerge item", AzureStorageUtils.PrintItem(item), ex);
-                throw;
-            }
+            var table = await GetTableAsync();
+
+            await table.ExecuteAsync(TableOperation.InsertOrMerge(item), GetRequestOptions(), null);
         }
 
         public async Task InsertOrMergeBatchAsync(IEnumerable<T> items)
         {
             items = items.ToArray();
-            try
+            
+            if (items.Any())
             {
-                if (items.Any())
+                var insertBatchOperation = new TableBatchOperation();
+                foreach (var item in items)
                 {
-                    var insertBatchOperation = new TableBatchOperation();
-                    foreach (var item in items)
-                    {
-                        insertBatchOperation.InsertOrMerge(item);
-                    }
-                    var table = await GetTable();
-                    await table.ExecuteLimitSafeBatchAsync(insertBatchOperation, GetRequestOptions(), null);
+                    insertBatchOperation.InsertOrMerge(item);
                 }
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(InsertOrMergeBatchAsync),
-                        AzureStorageUtils.PrintItems(items),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync(
-                        "Table storage: " + _tableName, nameof(InsertOrMergeBatchAsync), AzureStorageUtils.PrintItems(items), ex);
-                throw;
+                var table = await GetTableAsync();
+                await table.ExecuteLimitSafeBatchAsync(insertBatchOperation, GetRequestOptions(), null);
             }
         }
 
         public async Task<T> ReplaceAsync(string partitionKey, string rowKey, Func<T, T> replaceAction)
         {
-            object itm = "Not read";
-            try
+            while (true)
             {
-                while (true)
-                    try
+                try
+                {
+                    var entity = await GetDataAsync(partitionKey, rowKey);
+                    if (entity != null)
                     {
-                        var entity = await GetDataAsync(partitionKey, rowKey);
-                        if (entity != null)
+                        var result = replaceAction(entity);
+                        if (result != null)
                         {
-                            var result = replaceAction(entity);
-                            itm = result;
-                            if (result != null)
-                            {
-                                var table = await GetTable();
-                                await table.ExecuteAsync(TableOperation.Replace(result), GetRequestOptions(), null);
-                            }
-
-                            return result;
+                            var table = await GetTableAsync();
+                            await table.ExecuteAsync(TableOperation.Replace(result), GetRequestOptions(), null);
                         }
 
-                        return null;
+                        return result;
                     }
-                    catch (StorageException e)
-                    {
-                        // Если поймали precondition fall = 412, значит в другом потоке данную сущность успели поменять
-                        // - нужно повторить операцию, пока не исполнится без ошибок
-                        if (e.RequestInformation.HttpStatusCode != 412)
-                            throw;
-                    }
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(ReplaceAsync),
-                        AzureStorageUtils.PrintItem(itm),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "Replace item", AzureStorageUtils.PrintItem(itm), ex);
-                throw;
+
+                    return null;
+                }
+                catch (StorageException e)
+                {
+                    // Если поймали precondition fall = 412, значит в другом потоке данную сущность успели поменять
+                    // - нужно повторить операцию, пока не исполнится без ошибок
+                    if (e.RequestInformation.HttpStatusCode != 412)
+                        throw;
+                }
             }
         }
 
         public async Task<T> MergeAsync(string partitionKey, string rowKey, Func<T, T> mergeAction)
         {
-            object itm = "Not read";
-
-            try
+            while (true)
             {
-                while (true)
-                    try
+                try
+                {
+                    var entity = await GetDataAsync(partitionKey, rowKey);
+                    if (entity != null)
                     {
-                        var entity = await GetDataAsync(partitionKey, rowKey);
-                        if (entity != null)
+                        var result = mergeAction(entity);
+                        if (result != null)
                         {
-                            var result = mergeAction(entity);
-                            itm = result;
-                            if (result != null)
-                            {
-                                var table = await GetTable();
-                                await table.ExecuteAsync(TableOperation.Merge(result), GetRequestOptions(), null);
-                            }
-
-                            return result;
+                            var table = await GetTableAsync();
+                            await table.ExecuteAsync(TableOperation.Merge(result), GetRequestOptions(), null);
                         }
-                        return null;
+
+                        return result;
                     }
-                    catch (StorageException e)
-                    {
-                        // Если поймали precondition fall = 412, значит в другом потоке данную сущность успели поменять
-                        // - нужно повторить операцию, пока не исполнится без ошибок
-                        if (e.RequestInformation.HttpStatusCode != 412)
-                            throw;
-                    }
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(MergeAsync),
-                        AzureStorageUtils.PrintItem(itm),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, nameof(MergeAsync), AzureStorageUtils.PrintItem(itm), ex);
-                throw;
+                    return null;
+                }
+                catch (StorageException e)
+                {
+                    // Если поймали precondition fall = 412, значит в другом потоке данную сущность успели поменять
+                    // - нужно повторить операцию, пока не исполнится без ошибок
+                    if (e.RequestInformation.HttpStatusCode != 412)
+                        throw;
+                }
             }
         }
 
@@ -266,82 +256,37 @@ namespace AzureStorage.Tables
 
             foreach (var entity in entites)
                 operationsBatch.Add(TableOperation.InsertOrReplace(entity));
-            var table = await GetTable();
+            var table = await GetTableAsync();
 
             await table.ExecuteLimitSafeBatchAsync(operationsBatch, GetRequestOptions(), null);
         }
 
         public virtual async Task InsertOrReplaceAsync(T item)
         {
-            try
-            {
-                var table = await GetTable();
-                await table.ExecuteAsync(TableOperation.InsertOrReplace(item), GetRequestOptions(), null);
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(InsertOrReplaceAsync),
-                        AzureStorageUtils.PrintItem(item),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "InsertOrReplace item", AzureStorageUtils.PrintItem(item), ex);
-                throw;
-            }
+            var table = await GetTableAsync();
+            await table.ExecuteAsync(TableOperation.InsertOrReplace(item), GetRequestOptions(), null);
         }
 
         public async Task InsertOrReplaceAsync(IEnumerable<T> items)
         {
             items = items.ToArray();
-            try
+
+            if (items.Any())
             {
-                if (items.Any())
+                var insertBatchOperation = new TableBatchOperation();
+                foreach (var item in items)
                 {
-                    var insertBatchOperation = new TableBatchOperation();
-                    foreach (var item in items)
-                    {
-                        insertBatchOperation.InsertOrReplace(item);
-                    }
-                    var table = await GetTable();
-                    await table.ExecuteLimitSafeBatchAsync(insertBatchOperation, GetRequestOptions(), null);
+                    insertBatchOperation.InsertOrReplace(item);
                 }
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(InsertOrReplaceAsync),
-                        AzureStorageUtils.PrintItems(items),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync(
-                        "Table storage: " + _tableName, "InsertOrReplaceAsync batch", AzureStorageUtils.PrintItems(items), ex);
-                throw;
+                var table = await GetTableAsync();
+                await table.ExecuteLimitSafeBatchAsync(insertBatchOperation, GetRequestOptions(), null);
             }
         }
 
         public virtual async Task DeleteAsync(T item)
         {
-            try
-            {
-                var table = await GetTable();
-                await table.ExecuteAsync(TableOperation.Delete(item), GetRequestOptions(), null);
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(DeleteAsync),
-                        AzureStorageUtils.PrintItem(item),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "Delete item", AzureStorageUtils.PrintItem(item), ex);
-                throw;
-            }
+            var table = await GetTableAsync();
+            await table.ExecuteAsync(TableOperation.Delete(item), GetRequestOptions(), null);
         }
 
         public async Task<T> DeleteAsync(string partitionKey, string rowKey)
@@ -372,28 +317,14 @@ namespace AzureStorage.Tables
         public async Task DeleteAsync(IEnumerable<T> items)
         {
             items = items.ToArray();
-            try
+
+            if (items.Any())
             {
-                if (items.Any())
-                {
-                    var deleteBatchOperation = new TableBatchOperation();
-                    foreach (var item in items)
-                        deleteBatchOperation.Delete(item);
-                    var table = await GetTable();
-                    await table.ExecuteLimitSafeBatchAsync(deleteBatchOperation, GetRequestOptions(), null);
-                }
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(DeleteAsync),
-                        AzureStorageUtils.PrintItems(items),
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "DeleteAsync batch", AzureStorageUtils.PrintItems(items), ex);
-                throw;
+                var deleteBatchOperation = new TableBatchOperation();
+                foreach (var item in items)
+                    deleteBatchOperation.Delete(item);
+                var table = await GetTableAsync();
+                await table.ExecuteLimitSafeBatchAsync(deleteBatchOperation, GetRequestOptions(), null);
             }
         }
 
@@ -418,6 +349,11 @@ namespace AzureStorage.Tables
             return this[item.PartitionKey, item.RowKey] != null;
         }
 
+        public virtual async Task<bool> RecordExistsAsync(T item)
+        {
+            return await GetDataAsync(item.PartitionKey, item.RowKey) != null;
+        }
+
         public virtual T this[string partition, string row] => GetDataAsync(partition, row).RunSync();
 
         public async Task<IEnumerable<T>> GetDataAsync(string partitionKey, IEnumerable<string> rowKeys,
@@ -427,7 +363,7 @@ namespace AzureStorage.Tables
 
             await Task.WhenAll(
                 rowKeys.ToPieces(pieceSize).Select(piece =>
-                        ExecuteQueryAsync("GetDataWithMutipleRows",
+                        ExecuteQueryAsync(
                             AzureStorageUtils.QueryGenerator<T>.MultipleRowKeys(partitionKey, piece.ToArray()), filter,
                             items =>
                             {
@@ -450,7 +386,7 @@ namespace AzureStorage.Tables
 
             await Task.WhenAll(
                 partitionKeys.ToPieces(pieceSize).Select(piece =>
-                        ExecuteQueryAsync("GetDataWithMutiplePartitionKeys",
+                        ExecuteQueryAsync(
                             AzureStorageUtils.QueryGenerator<T>.MultiplePartitionKeys(piece.ToArray()), filter,
                             items =>
                             {
@@ -473,7 +409,7 @@ namespace AzureStorage.Tables
 
             await Task.WhenAll(
                 keys.ToPieces(pieceSize).Select(piece =>
-                        ExecuteQueryAsync("GetDataWithMoltipleKeysAsync",
+                        ExecuteQueryAsync(
                             AzureStorageUtils.QueryGenerator<T>.MultipleKeys(piece), filter,
                             items =>
                             {
@@ -492,13 +428,13 @@ namespace AzureStorage.Tables
         public Task GetDataByChunksAsync(Func<IEnumerable<T>, Task> chunks)
         {
             var rangeQuery = new TableQuery<T>();
-            return ExecuteQueryAsync("GetDataByChunksAsync", rangeQuery, null, async itms => { await chunks(itms); });
+            return ExecuteQueryAsync(rangeQuery, null, async itms => { await chunks(itms); });
         }
 
         public Task GetDataByChunksAsync(Action<IEnumerable<T>> chunks)
         {
             var rangeQuery = new TableQuery<T>();
-            return ExecuteQueryAsync("GetDataByChunksAsync", rangeQuery, null, itms =>
+            return ExecuteQueryAsync(rangeQuery, null, itms =>
             {
                 chunks(itms);
                 return true;
@@ -515,36 +451,20 @@ namespace AzureStorage.Tables
         {
             var rangeQuery = CompileTableQuery(partitionKey);
 
-            return ExecuteQueryAsync("ScanDataAsync", rangeQuery, null, chunk);
+            return ExecuteQueryAsync(rangeQuery, null, chunk);
         }
 
         public Task ScanDataAsync(TableQuery<T> rangeQuery, Func<IEnumerable<T>, Task> chunk)
         {
-            return ExecuteQueryAsync("ScanDataAsync", rangeQuery, null, chunk);
+            return ExecuteQueryAsync(rangeQuery, null, chunk);
         }
 
         public virtual async Task<T> GetDataAsync(string partition, string row)
         {
-            try
-            {
-                var retrieveOperation = TableOperation.Retrieve<T>(partition, row);
-                var table = await GetTable();
-                var retrievedResult = await table.ExecuteAsync(retrieveOperation, GetRequestOptions(), null);
-                return (T)retrievedResult.Result;
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(GetDataAsync),
-                        "partitionId=" + partition + "; rowId=" + row,
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync(
-                        "Table storage: " + _tableName, "Get item async by partId and rowId", "partitionId=" + partition + "; rowId=" + row, ex);
-                throw;
-            }
+            var retrieveOperation = TableOperation.Retrieve<T>(partition, row);
+            var table = await GetTableAsync();
+            var retrievedResult = await table.ExecuteAsync(retrieveOperation, GetRequestOptions(), null);
+            return (T) retrievedResult.Result;
         }
 
 
@@ -554,7 +474,7 @@ namespace AzureStorage.Tables
 
             T result = null;
 
-            await ExecuteQueryAsync("ScanDataAsync", query, itm => true,
+            await ExecuteQueryAsync(query, itm => true,
                 itms =>
                 {
                     result = dataToSearch(itms);
@@ -572,7 +492,7 @@ namespace AzureStorage.Tables
             var query = AzureStorageUtils.QueryGenerator<T>.RowKeyOnly.GetTableQuery(rowKeys);
             var result = new List<T>();
 
-            await ExecuteQueryAsync("GetDataRowKeysOnlyAsync", query, null, chunk =>
+            await ExecuteQueryAsync(query, null, chunk =>
             {
                 result.AddRange(chunk);
                 return Task.FromResult(0);
@@ -584,7 +504,7 @@ namespace AzureStorage.Tables
         public async Task<IEnumerable<T>> WhereAsyncc(TableQuery<T> rangeQuery, Func<T, Task<bool>> filter = null)
         {
             var result = new List<T>();
-            await ExecuteQueryAsync2("WhereAsyncc", rangeQuery, filter, itm =>
+            await ExecuteQueryAsync2(rangeQuery, filter, itm =>
             {
                 result.Add(itm);
                 return true;
@@ -597,7 +517,7 @@ namespace AzureStorage.Tables
         {
             var rangeQuery = new TableQuery<T>();
             var result = new List<T>();
-            await ExecuteQueryAsync("GetDataAsync", rangeQuery, filter, itms =>
+            await ExecuteQueryAsync(rangeQuery, filter, itms =>
             {
                 result.AddRange(itms);
                 return true;
@@ -610,7 +530,7 @@ namespace AzureStorage.Tables
             var rangeQuery = CompileTableQuery(partition);
             var result = new List<T>();
 
-            await ExecuteQueryAsync("GetDataAsync", rangeQuery, filter, itms =>
+            await ExecuteQueryAsync(rangeQuery, filter, itms =>
             {
                 result.AddRange(itms);
                 return true;
@@ -624,7 +544,7 @@ namespace AzureStorage.Tables
             var rangeQuery = CompileTableQuery(partition);
             var result = new List<T>();
 
-            await ExecuteQueryAsync("GetTopRecordAsync", rangeQuery, null, itms =>
+            await ExecuteQueryAsync(rangeQuery, null, itms =>
             {
                 result.AddRange(itms);
                 return false;
@@ -638,7 +558,7 @@ namespace AzureStorage.Tables
             var rangeQuery = CompileTableQuery(partition);
             var result = new List<T>();
 
-            await ExecuteQueryAsync("GetTopRecordsAsync", rangeQuery, null, itms =>
+            await ExecuteQueryAsync(rangeQuery, null, itms =>
             {
                 result.AddRange(itms);
 
@@ -654,7 +574,7 @@ namespace AzureStorage.Tables
         public async Task<IEnumerable<T>> WhereAsync(TableQuery<T> rangeQuery, Func<T, bool> filter = null)
         {
             var result = new List<T>();
-            await ExecuteQueryAsync("WhereAsync", rangeQuery, filter, itms =>
+            await ExecuteQueryAsync(rangeQuery, filter, itms =>
             {
                 result.AddRange(itms);
                 return true;
@@ -664,7 +584,7 @@ namespace AzureStorage.Tables
 
         public Task ExecuteAsync(TableQuery<T> rangeQuery, Action<IEnumerable<T>> result, Func<bool> stopCondition = null)
         {
-            return ExecuteQueryAsync("ExecuteAsync", rangeQuery, null, itms =>
+            return ExecuteQueryAsync(rangeQuery, null, itms =>
             {
                 result(itms);
 
@@ -687,148 +607,70 @@ namespace AzureStorage.Tables
         {
             var table = GetTableReference();
 
-            try
-            {
-                await table.CreateIfNotExistsAsync();
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        nameof(CreateTableIfNotExists),
-                        "unknown case",
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "CreateTable error", "unknown case", ex);
-                throw;
-            }
+            await table.CreateIfNotExistsAsync();
 
             _tableCreated = true;
 
             return table;
         }
 
-        private async Task<CloudTable> GetTable()
+        private async Task<CloudTable> GetTableAsync()
         {
             return _tableCreated ? GetTableReference() : await CreateTableIfNotExists();
         }
 
-        private async Task ExecuteQueryAsync(string processName, TableQuery<T> rangeQuery, Func<T, bool> filter,
+        private async Task ExecuteQueryAsync(TableQuery<T> rangeQuery, Func<T, bool> filter,
             Func<IEnumerable<T>, Task> yieldData)
         {
-            try
+            TableContinuationToken tableContinuationToken = null;
+            var table = await GetTableAsync();
+            do
             {
-                TableContinuationToken tableContinuationToken = null;
-                var table = await GetTable();
-                do
-                {
-                    var queryResponse = await table.ExecuteQuerySegmentedAsync(rangeQuery, tableContinuationToken, GetRequestOptions(), null);
-                    tableContinuationToken = queryResponse.ContinuationToken;
-                    await yieldData(AzureStorageUtils.ApplyFilter(queryResponse.Results, filter));
-                } while (tableContinuationToken != null);
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        processName,
-                        rangeQuery.FilterString ?? "[null]",
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, processName, rangeQuery.FilterString ?? "[null]", ex);
-                throw;
-            }
+                var queryResponse = await table.ExecuteQuerySegmentedAsync(rangeQuery, tableContinuationToken, GetRequestOptions(), null);
+                tableContinuationToken = queryResponse.ContinuationToken;
+                await yieldData(AzureStorageUtils.ApplyFilter(queryResponse.Results, filter));
+            } while (tableContinuationToken != null);
         }
 
 
         /// <summary>
         ///     Выполнить запрос асинхроно
         /// </summary>
-        /// <param name="processName">Имя процесса (для лога)</param>
         /// <param name="rangeQuery">Параметры запроса</param>
         /// <param name="filter">Фильтрация запроса</param>
         /// <param name="yieldData">Данные которые мы выдаем наружу. Если возвращается false - данные можно больше не запрашивать</param>
         /// <returns></returns>
-        private async Task ExecuteQueryAsync(string processName, TableQuery<T> rangeQuery, Func<T, bool> filter,
-            Func<IEnumerable<T>, bool> yieldData)
+        private async Task ExecuteQueryAsync(TableQuery<T> rangeQuery, Func<T, bool> filter, Func<IEnumerable<T>, bool> yieldData)
         {
-            try
+            TableContinuationToken tableContinuationToken = null;
+            var table = await GetTableAsync();
+            do
             {
-                TableContinuationToken tableContinuationToken = null;
-                var table = await GetTable();
-                do
-                {
-                    var queryResponse = await table.ExecuteQuerySegmentedAsync(rangeQuery, tableContinuationToken, GetRequestOptions(), null);
-                    tableContinuationToken = queryResponse.ContinuationToken;
-                    var shouldWeContinue = yieldData(AzureStorageUtils.ApplyFilter(queryResponse.Results, filter));
-                    if (!shouldWeContinue)
-                        break;
-                } while (tableContinuationToken != null);
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        processName,
-                        rangeQuery.FilterString ?? "[null]",
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, processName, rangeQuery.FilterString ?? "[null]", ex);
-                throw;
-            }
+                var queryResponse = await table.ExecuteQuerySegmentedAsync(rangeQuery, tableContinuationToken, GetRequestOptions(), null);
+                tableContinuationToken = queryResponse.ContinuationToken;
+                var shouldWeContinue = yieldData(AzureStorageUtils.ApplyFilter(queryResponse.Results, filter));
+                if (!shouldWeContinue)
+                    break;
+            } while (tableContinuationToken != null);
         }
 
-        private async Task ExecuteQueryAsync2(string processName, TableQuery<T> rangeQuery, Func<T, Task<bool>> filter,
-            Func<T, bool> yieldData)
+        private async Task ExecuteQueryAsync2(TableQuery<T> rangeQuery, Func<T, Task<bool>> filter, Func<T, bool> yieldData)
         {
-            try
+            TableContinuationToken tableContinuationToken = null;
+            var table = await GetTableAsync();
+            do
             {
-                TableContinuationToken tableContinuationToken = null;
-                var table = await GetTable();
-                do
-                {
-                    var queryResponse = await table.ExecuteQuerySegmentedAsync(rangeQuery, tableContinuationToken, GetRequestOptions(), null);
-                    tableContinuationToken = queryResponse.ContinuationToken;
+                var queryResponse = await table.ExecuteQuerySegmentedAsync(rangeQuery, tableContinuationToken, GetRequestOptions(), null);
+                tableContinuationToken = queryResponse.ContinuationToken;
 
-                    foreach (var itm in queryResponse.Results)
-                        if ((filter == null) || await filter(itm))
-                        {
-                            var shouldWeContinue = yieldData(itm);
-                            if (!shouldWeContinue)
-                                return;
-                        }
-                } while (tableContinuationToken != null);
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                    await _log.WriteWarningAsync(
-                        "Table storage: " + _tableName,
-                        processName,
-                        rangeQuery.FilterString ?? "[null]",
-                        ex.GetBaseException().Message);
-                else
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, processName, rangeQuery.FilterString ?? "[null]", ex);
-                throw;
-            }
-        }
-
-
-        private async Task HandleException(T item, Exception ex, IEnumerable<int> notLogCodes)
-        {
-            var storageException = ex as StorageException;
-            if (storageException != null)
-            {
-                if (!storageException.HandleStorageException(notLogCodes))
-                    await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "Insert item", AzureStorageUtils.PrintItem(item), ex);
-            }
-            else
-            {
-                await _log.WriteFatalErrorAsync("Table storage: " + _tableName, "Insert item", AzureStorageUtils.PrintItem(item), ex);
-            }
+                foreach (var itm in queryResponse.Results)
+                    if ((filter == null) || await filter(itm))
+                    {
+                        var shouldWeContinue = yieldData(itm);
+                        if (!shouldWeContinue)
+                            return;
+                    }
+            } while (tableContinuationToken != null);
         }
 
         private TableQuery<T> CompileTableQuery(string partition)

--- a/src/Lykke.AzureStorage/Tables/AzureTableStorageLocal.cs
+++ b/src/Lykke.AzureStorage/Tables/AzureTableStorageLocal.cs
@@ -15,6 +15,8 @@ namespace AzureStorage.Tables
 {
     public class AzureTableStorageLocal<T> : INoSQLTableStorage<T> where T : class, ITableEntity, new()
     {
+        public string Name => $"{_prefix}:{_tableName}";
+
         private readonly string _prefix;
         private readonly string _tableName;
 
@@ -122,6 +124,11 @@ namespace AzureStorage.Tables
         public bool RecordExists(T item)
         {
             return GetDataAsync(item.PartitionKey, item.RowKey).Result != null;
+        }
+
+        public async Task<bool> RecordExistsAsync(T item)
+        {
+            return await GetDataAsync(item.PartitionKey, item.RowKey) != null;
         }
 
         public Task DoBatchAsync(TableBatchOperation batch)

--- a/src/Lykke.AzureStorage/Tables/Decorators/LogExceptionsAzureTableStorageDecorator.cs
+++ b/src/Lykke.AzureStorage/Tables/Decorators/LogExceptionsAzureTableStorageDecorator.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using Common.Extensions;
+using Common.Log;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+using Newtonsoft.Json;
+
+namespace AzureStorage.Tables.Decorators
+{
+    /// <summary>
+    /// Decorator which logs Azure Table Storage exceptions
+    /// </summary>
+    internal class LogExceptionsAzureTableStorageDecorator<TEntity> : INoSQLTableStorage<TEntity> 
+        where TEntity : ITableEntity, new()
+    {
+        public string Name => _impl.Name;
+
+        private readonly INoSQLTableStorage<TEntity> _impl;
+        private readonly ILog _log;
+        private readonly JsonSerializerSettings _dumpSettings;
+
+        public LogExceptionsAzureTableStorageDecorator(INoSQLTableStorage<TEntity> impl, ILog log)
+        {
+            _impl = impl;
+            _log = log;
+
+            _dumpSettings = new JsonSerializerSettings
+            {
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                Formatting = Formatting.Indented,
+                Culture = CultureInfo.InvariantCulture
+            };
+        }
+
+        #region INoSqlTableStorage{TEntity} decoration
+
+        public IEnumerator<TEntity> GetEnumerator() 
+            => Wrap(() => _impl.GetEnumerator(), nameof(GetEnumerator));
+
+        IEnumerator IEnumerable.GetEnumerator() 
+            => Wrap(() => ((IEnumerable) _impl).GetEnumerator(), nameof(GetEnumerator));
+
+        TEntity INoSQLTableStorage<TEntity>.this[string partition, string row] 
+            => Wrap(() => _impl[partition, row], "[partition, row]", new {partition, row});
+
+        IEnumerable<TEntity> INoSQLTableStorage<TEntity>.this[string partition] 
+            => Wrap(() => _impl[partition], "[partition]", new{partition});
+
+        public Task InsertAsync(TEntity item, params int[] notLogCodes) 
+            => WrapAsync(() => _impl.InsertAsync(item, notLogCodes), nameof(InsertAsync), item, notLogCodes);
+
+        public Task InsertAsync(IEnumerable<TEntity> items) 
+            => WrapAsync(() => _impl.InsertAsync(items), nameof(InsertAsync), items);
+
+        public Task InsertOrMergeAsync(TEntity item) 
+            => WrapAsync(() => _impl.InsertOrMergeAsync(item), nameof(InsertOrMergeAsync), item);
+
+        public Task InsertOrMergeBatchAsync(IEnumerable<TEntity> items) 
+            => WrapAsync(() => _impl.InsertOrMergeBatchAsync(items), nameof(InsertOrMergeBatchAsync), items);
+
+        public Task<TEntity> ReplaceAsync(string partitionKey, string rowKey, Func<TEntity, TEntity> item)
+        {
+            object result = "Not read";
+
+            return WrapAsync(() => _impl.ReplaceAsync(partitionKey, rowKey, entity =>
+                {
+                    var replacedItem = item(entity);
+                    result = replacedItem;
+                    return replacedItem;
+                }),
+                nameof(ReplaceAsync),
+                result);
+        }
+
+        public Task<TEntity> MergeAsync(string partitionKey, string rowKey, Func<TEntity, TEntity> item)
+        {
+            object result = "Not read";
+
+            return WrapAsync(() => _impl.MergeAsync(partitionKey, rowKey, entity =>
+                {
+                    var replacedItem = item(entity);
+                    result = replacedItem;
+                    return replacedItem;
+                }),
+                nameof(MergeAsync),
+                result);
+        }
+
+        public Task InsertOrReplaceBatchAsync(IEnumerable<TEntity> entities) 
+            => WrapAsync(() => _impl.InsertOrReplaceBatchAsync(entities), nameof(InsertOrReplaceBatchAsync), entities);
+
+        public Task InsertOrReplaceAsync(TEntity item) 
+            => WrapAsync(() => _impl.InsertOrReplaceAsync(item), nameof(InsertOrReplaceAsync), item);
+
+        public Task InsertOrReplaceAsync(IEnumerable<TEntity> items) 
+            => WrapAsync(() => _impl.InsertOrReplaceAsync(items), nameof(InsertOrReplaceAsync), items);
+
+        public Task DeleteAsync(TEntity item) 
+            => WrapAsync(() => _impl.DeleteAsync(item), nameof(DeleteAsync), item);
+
+        public Task<TEntity> DeleteAsync(string partitionKey, string rowKey) 
+            => WrapAsync(() => _impl.DeleteAsync(partitionKey, rowKey), nameof(DeleteAsync), new {partitionKey, rowKey});
+
+        public Task<bool> DeleteIfExistAsync(string partitionKey, string rowKey) 
+            => WrapAsync(() => _impl.DeleteIfExistAsync(partitionKey, rowKey), nameof(DeleteIfExistAsync), new {partitionKey, rowKey});
+
+        public Task DeleteAsync(IEnumerable<TEntity> items) 
+            => WrapAsync(() => _impl.DeleteAsync(items), nameof(DeleteAsync), items);
+
+        public Task<bool> CreateIfNotExistsAsync(TEntity item) 
+            => WrapAsync(() => _impl.CreateIfNotExistsAsync(item), nameof(CreateIfNotExistsAsync), item);
+
+        public bool RecordExists(TEntity item) 
+            => Wrap(() => _impl.RecordExists(item), nameof(RecordExists), item);
+
+        public Task<bool> RecordExistsAsync(TEntity item) 
+            => WrapAsync(() => _impl.RecordExistsAsync(item), nameof(RecordExistsAsync), item);
+
+        public Task<TEntity> GetDataAsync(string partition, string row) 
+            => WrapAsync(() => _impl.GetDataAsync(partition, row), nameof(GetDataAsync), new {partition, row});
+
+        public Task<IList<TEntity>> GetDataAsync(Func<TEntity, bool> filter = null) 
+            => WrapAsync(() => _impl.GetDataAsync(filter), nameof(GetDataAsync));
+
+        public Task<IEnumerable<TEntity>> GetDataAsync(string partitionKey, IEnumerable<string> rowKeys, int pieceSize = 100, Func<TEntity, bool> filter = null) 
+            => WrapAsync(() => _impl.GetDataAsync(partitionKey, rowKeys, pieceSize, filter), nameof(GetDataAsync), new {partitionKey, rowKeys, pieceSize});
+
+        public Task<IEnumerable<TEntity>> GetDataAsync(IEnumerable<string> partitionKeys, int pieceSize = 100, Func<TEntity, bool> filter = null) 
+            => WrapAsync(() => _impl.GetDataAsync(partitionKeys, pieceSize, filter), nameof(GetDataAsync), new {partitionKeys, pieceSize});
+
+        public Task<IEnumerable<TEntity>> GetDataAsync(IEnumerable<Tuple<string, string>> keys, int pieceSize = 100, Func<TEntity, bool> filter = null) 
+            => WrapAsync(() => _impl.GetDataAsync(keys, pieceSize, filter), nameof(GetDataAsync), new {keys, pieceSize});
+
+        public Task GetDataByChunksAsync(Func<IEnumerable<TEntity>, Task> chunks) 
+            => WrapAsync(() => _impl.GetDataByChunksAsync(chunks), nameof(GetDataByChunksAsync));
+
+        public Task GetDataByChunksAsync(Action<IEnumerable<TEntity>> chunks) 
+            => WrapAsync(() => _impl.GetDataByChunksAsync(chunks), nameof(GetDataByChunksAsync));
+
+        public Task GetDataByChunksAsync(string partitionKey, Action<IEnumerable<TEntity>> chunks) 
+            => WrapAsync(() => _impl.GetDataByChunksAsync(partitionKey, chunks), nameof(GetDataByChunksAsync), new {partitionKey});
+
+        public Task ScanDataAsync(string partitionKey, Func<IEnumerable<TEntity>, Task> chunk) 
+            => WrapAsync(() => _impl.ScanDataAsync(partitionKey, chunk), nameof(ScanDataAsync), new {partitionKey});
+
+        public Task ScanDataAsync(TableQuery<TEntity> rangeQuery, Func<IEnumerable<TEntity>, Task> chunk) 
+            => WrapAsync(() => _impl.ScanDataAsync(rangeQuery, chunk), nameof(ScanDataAsync), rangeQuery.FilterString);
+
+        public Task<TEntity> FirstOrNullViaScanAsync(string partitionKey, Func<IEnumerable<TEntity>, TEntity> dataToSearch) 
+            => WrapAsync(() => _impl.FirstOrNullViaScanAsync(partitionKey, dataToSearch), nameof(FirstOrNullViaScanAsync), new {partitionKey});
+
+        public Task<IEnumerable<TEntity>> GetDataAsync(string partition, Func<TEntity, bool> filter = null) 
+            => WrapAsync(() => _impl.GetDataAsync(partition, filter), nameof(GetDataAsync), new {partition});
+
+        public Task<TEntity> GetTopRecordAsync(string partition) 
+            => WrapAsync(() => _impl.GetTopRecordAsync(partition), nameof(GetTopRecordAsync), new {partition});
+
+        public Task<IEnumerable<TEntity>> GetTopRecordsAsync(string partition, int n) 
+            => WrapAsync(() => _impl.GetTopRecordsAsync(partition, n), nameof(GetTopRecordsAsync), new {partition, n});
+
+        public Task<IEnumerable<TEntity>> GetDataRowKeysOnlyAsync(IEnumerable<string> rowKeys) 
+            => WrapAsync(() => _impl.GetDataRowKeysOnlyAsync(rowKeys), nameof(GetDataRowKeysOnlyAsync), rowKeys);
+
+        public Task<IEnumerable<TEntity>> WhereAsyncc(TableQuery<TEntity> rangeQuery, Func<TEntity, Task<bool>> filter = null) 
+            => WrapAsync(() => _impl.WhereAsyncc(rangeQuery, filter), nameof(WhereAsyncc), rangeQuery.FilterString);
+
+        public Task<IEnumerable<TEntity>> WhereAsync(TableQuery<TEntity> rangeQuery, Func<TEntity, bool> filter = null) 
+            => WrapAsync(() => _impl.WhereAsync(rangeQuery, filter), nameof(WhereAsync), rangeQuery.FilterString);
+
+        public Task ExecuteAsync(TableQuery<TEntity> rangeQuery, Action<IEnumerable<TEntity>> yieldResult, Func<bool> stopCondition = null) 
+            => WrapAsync(() => _impl.ExecuteAsync(rangeQuery, yieldResult, stopCondition), nameof(ExecuteAsync), rangeQuery.FilterString);
+
+        public Task DoBatchAsync(TableBatchOperation batch) 
+            => WrapAsync(() => _impl.DoBatchAsync(batch), nameof(DoBatchAsync));
+
+        #endregion
+
+
+        #region Private members
+
+        private async Task<TResult> WrapAsync<TResult>(Func<Task<TResult>> func, string process, object context = null, IEnumerable<int> notLogAzureCodes = null)
+        {
+            try
+            {
+                return await func();
+            }
+            catch (Exception ex)
+            {
+                await HandleExceptionAsync(ex, process, context, notLogAzureCodes);
+                throw;
+            }
+        }
+
+        private async Task WrapAsync(Func<Task> func, string process, object context = null, IEnumerable<int> notLogAzureCodes = null)
+        {
+            try
+            {
+                await func();
+            }
+            catch (Exception ex)
+            {
+                await HandleExceptionAsync(ex, process, context, notLogAzureCodes);
+                throw;
+            }
+        }
+
+        private TResult Wrap<TResult>(Func<TResult> func, string process, object context = null, IEnumerable<int> notLogAzureCodes = null)
+        {
+            try
+            {
+                return func();
+            }
+            catch (Exception ex)
+            {
+                HandleExceptionAsync(ex, process, context, notLogAzureCodes).RunSync();
+                throw;
+            }
+        }
+
+        private async Task HandleExceptionAsync(Exception exception, string process, object context, IEnumerable<int> notLogAzureCodes)
+        {
+            if (exception is TaskCanceledException)
+            {
+                await _log.WriteWarningAsync(
+                    $"Table storage: {Name}",
+                    process,
+                    Dump(context),
+                    exception.GetBaseException().Message);
+            }
+            else if (exception is StorageException storageException)
+            {
+                if (notLogAzureCodes == null || !storageException.HandleStorageException(notLogAzureCodes))
+                {
+                    await _log.WriteErrorAsync(
+                        $"Table storage: {Name}",
+                        process,
+                        Dump(context),
+                        exception);
+                }
+            }
+            else
+            {
+                await _log.WriteErrorAsync(
+                    $"Table storage: {Name}",
+                    process,
+                    Dump(context),
+                    exception);
+            }
+        }
+
+        private string Dump(object context)
+        {
+            return JsonConvert.SerializeObject(context, _dumpSettings);
+        }
+        
+        #endregion
+    }
+}

--- a/src/Lykke.AzureStorage/Tables/Decorators/ReloadingConnectionStringOnFailureAzureTableStorageDecorator.cs
+++ b/src/Lykke.AzureStorage/Tables/Decorators/ReloadingConnectionStringOnFailureAzureTableStorageDecorator.cs
@@ -10,9 +10,11 @@ namespace AzureStorage.Tables.Decorators
     /// <summary>
     /// Decorator, which adds reloading ConnectionString on authenticate failure to operations of <see cref="INoSQLTableStorage{T}"/> implementation
     /// </summary>
-    public class ReloadingConnectionStringOnFailureAzureTableStorageDecorator<TEntity> : ReloadingOnFailureDecoratorBase<INoSQLTableStorage<TEntity>>, INoSQLTableStorage<TEntity> 
+    internal class ReloadingConnectionStringOnFailureAzureTableStorageDecorator<TEntity> : ReloadingOnFailureDecoratorBase<INoSQLTableStorage<TEntity>>, INoSQLTableStorage<TEntity> 
         where TEntity : ITableEntity, new()
     {
+        public string Name => Wrap(x => x.Name);
+
         protected override Func<Task<INoSQLTableStorage<TEntity>>> MakeStorage { get; }
 
         public ReloadingConnectionStringOnFailureAzureTableStorageDecorator(Func<Task<INoSQLTableStorage<TEntity>>> makeStorage)
@@ -76,6 +78,9 @@ namespace AzureStorage.Tables.Decorators
 
         public bool RecordExists(TEntity item)
             => Wrap(x => x.RecordExists(item));
+
+        public Task<bool> RecordExistsAsync(TEntity item)
+            => WrapAsync(x => x.RecordExistsAsync(item));
 
         public Task<TEntity> GetDataAsync(string partition, string row)
             => WrapAsync(x => x.GetDataAsync(partition, row));

--- a/src/Lykke.AzureStorage/Tables/NoSqlTableInMemory.cs
+++ b/src/Lykke.AzureStorage/Tables/NoSqlTableInMemory.cs
@@ -88,8 +88,9 @@ namespace AzureStorage.Tables
 
     public class NoSqlTableInMemory<T> : INoSQLTableStorage<T> where T : class, ITableEntity, new()
     {
+        public string Name => "InMemory";
+        
         private readonly SemaphoreSlim _lockSlim = new SemaphoreSlim(1);
-
 
         public readonly ConcurrentDictionary<string, Partition> Partitions = new ConcurrentDictionary<string, Partition>();
 
@@ -351,6 +352,11 @@ namespace AzureStorage.Tables
         public bool RecordExists(T item)
         {
             return this[item.PartitionKey, item.RowKey] != null;
+        }
+
+        public Task<bool> RecordExistsAsync(T item)
+        {
+            return Task.Run(() => this[item.PartitionKey, item.RowKey] != null);
         }
 
         public void DoBatch(TableBatchOperation batch)

--- a/src/Lykke.AzureStorage/Tables/Templates/SetupByPartition.cs
+++ b/src/Lykke.AzureStorage/Tables/Templates/SetupByPartition.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Threading.Tasks;
 using Common.Log;
+using Lykke.SettingsReader;
 using Microsoft.WindowsAzure.Storage.Table;
 
 namespace AzureStorage.Tables.Templates
@@ -76,8 +77,8 @@ namespace AzureStorage.Tables.Templates
 
     public class AzureSetupByPartition : NoSqlSetupByPartition
     {
-        public AzureSetupByPartition(string connStr, string tableName, ILog log)
-            : base(new AzureTableStorage<SetupByPartitionEntity>(connStr, tableName, log))
+        public AzureSetupByPartition(IReloadingManager<string> connStr, string tableName, ILog log)
+            : base(AzureTableStorage<SetupByPartitionEntity>.Create(connStr, tableName, log))
         {
         }
     }

--- a/src/Lykke.AzureStorage/Tables/Templates/SetupEntity.cs
+++ b/src/Lykke.AzureStorage/Tables/Templates/SetupEntity.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Common.Extensions;
 using Common.Log;
+using Lykke.SettingsReader;
 
 namespace AzureStorage.Tables.Templates
 {
@@ -52,7 +53,7 @@ namespace AzureStorage.Tables.Templates
 
     public class NoSqlTableForSetup : NoSqlTableForSetupAbstract
     {
-        public NoSqlTableForSetup(string connStr, string tableName, ILog log) :
+        public NoSqlTableForSetup(IReloadingManager<string> connStr, string tableName, ILog log) :
             base(new AzureSetupByPartition(connStr, tableName, log))
         {
         }


### PR DESCRIPTION
- AzureTableStorageWithCache was renamed to CachedAzureTableStorageDecorator, moved to decorators and made internal
 - ReloadingConnectionStringOnFailureAzureTableStorageDecorator was made internal
- RetryOnFailureAzureTableStorageDecorator was made internal
- Obsolete ctor of AzureTableStorage was made private
- Logging was removed from AzureTableStorage
- All required deocrators applied in AzureTableStorage.Create method now
- AzureTableStorage.CreateWithCache factory method was added to create instance decorated with CachedAzureTableStorageDecorator, among required decorators
- RecordExistsAsync() was added to the INoSQLTableStorage
- Name was added to the INoSQLTableStorage
- Xml-docs was added to the INoSQLTableStorage