### PR TITLE
Table URI has been used instead of the table name as the table existence flag key

### DIFF
--- a/src/Lykke.AzureStorage/AzureStorageUtils.cs
+++ b/src/Lykke.AzureStorage/AzureStorageUtils.cs
@@ -145,7 +145,7 @@ namespace AzureStorage
                     partitionKey => tableStorage.WhereAsync(partitionKey, from, to, intervalOption, filter)
                         .ContinueWith(task =>
                         {
-                            lock (result) result.AddRange(task.Result);
+                            lock (result) result.AddRange(task.GetAwaiter().GetResult());
                         }))
                 );
 
@@ -805,7 +805,7 @@ namespace AzureStorage
 			await Task.WhenAll(tasks);
 
 
-			return tasks[0].Result;
+			return tasks[0].GetAwaiter().GetResult();
 		}
     }
 }

--- a/src/Lykke.AzureStorage/Blob/AzureBlobLocal.cs
+++ b/src/Lykke.AzureStorage/Blob/AzureBlobLocal.cs
@@ -17,7 +17,7 @@ namespace AzureStorage.Blob
             _host = host;
         }
 
-        public Stream this[string container, string key] => GetAsync(container, key).Result;       
+        public Stream this[string container, string key] => GetAsync(container, key).GetAwaiter().GetResult();       
 
 		public async Task<string> SaveBlobAsync(string container, string key, Stream bloblStream, bool anonymousAccess = false)
 		{

--- a/src/Lykke.AzureStorage/ReloadingOnFailureDecoratorBase.cs
+++ b/src/Lykke.AzureStorage/ReloadingOnFailureDecoratorBase.cs
@@ -64,7 +64,7 @@ namespace AzureStorage
         {
             try
             {
-                func(GetStorageAsync().Result);
+                func(GetStorageAsync().GetAwaiter().GetResult());
                 return;
             }
             catch (Exception ex)
@@ -75,14 +75,14 @@ namespace AzureStorage
                 }
             }
 
-            func(GetStorageAsync(reload: true).Result);
+            func(GetStorageAsync(reload: true).GetAwaiter().GetResult());
         }
 
         protected T Wrap<T>(Func<TStorage, T> func)
         {
             try
             {
-                return func(GetStorageAsync().Result);
+                return func(GetStorageAsync().GetAwaiter().GetResult());
             }
             catch (Exception ex)
             {
@@ -92,7 +92,7 @@ namespace AzureStorage
                 }
             }
 
-            return func(GetStorageAsync(reload: true).Result);
+            return func(GetStorageAsync(reload: true).GetAwaiter().GetResult());
         }
 
         protected async Task WrapAsync(Func<TStorage, Task> func)

--- a/src/Lykke.AzureStorage/Tables/AzureTableStorageTablesCreator.cs
+++ b/src/Lykke.AzureStorage/Tables/AzureTableStorageTablesCreator.cs
@@ -19,7 +19,7 @@ namespace AzureStorage.Tables
 
         public static async Task EnsureTableIsCreatedAsync(CloudTable table)
         {
-            if (CreatedTables.TryAdd(table.Name, default(byte)))
+            if (CreatedTables.TryAdd(table.Uri.ToString(), default(byte)))
             {
                 await table.CreateIfNotExistsAsync();
             }
@@ -27,7 +27,7 @@ namespace AzureStorage.Tables
 
         public static void InvalidateCreationCache(CloudTable table)
         {
-            CreatedTables.TryRemove(table.Name, out var _);
+            CreatedTables.TryRemove(table.Uri.ToString(), out var _);
         }
     }
 }

--- a/src/Lykke.AzureStorage/Tables/NoSqlTableInMemory.cs
+++ b/src/Lykke.AzureStorage/Tables/NoSqlTableInMemory.cs
@@ -623,7 +623,7 @@ namespace AzureStorage.Tables
                 var result = new List<T>();
 
                 foreach (var rowKey in rowKeys)
-                    result.AddRange(this.GetDataRowKeyOnlyAsync(rowKey).Result);
+                    result.AddRange(this.GetDataRowKeyOnlyAsync(rowKey).GetAwaiter().GetResult());
 
                 return (IEnumerable<T>)result;
             });


### PR DESCRIPTION
Table URI has been used instead of the table name as the table existence flag key to handle on the fly account changing.