### PR TITLE
Fix TableQuery with TakeCount in WhereAsync

### DIFF
--- a/src/Lykke.AzureStorage/Tables/AzureTableStorage.cs
+++ b/src/Lykke.AzureStorage/Tables/AzureTableStorage.cs
@@ -1012,6 +1012,10 @@ namespace AzureStorage.Tables
             await ExecuteQueryAsync(rangeQuery, filter, itms =>
             {
                 result.AddRange(itms);
+                if (rangeQuery.TakeCount.HasValue && result.Count >= query.TakeCount)
+                {
+                    return false;
+                }
                 return true;
             });
             return result;


### PR DESCRIPTION
If we pass TableQuery with TakeCount into WhereAsync() method, AzureTableStorage will now break the cycle in ExecuteQueryAsync() method even if we already have all the needed entities. 