### PR TITLE
Fix InsertOrReplace etag

### DIFF
--- a/src/Lykke.AzureStorage/Tables/AzureTableStorage.cs
+++ b/src/Lykke.AzureStorage/Tables/AzureTableStorage.cs
@@ -529,10 +529,14 @@ namespace AzureStorage.Tables
                     return true;
                 }
                 catch (StorageException e) when (
-                    e.RequestInformation.ExtendedErrorInformation.ErrorCode == TableErrorCodeStrings.UpdateConditionNotSatisfied || 
-                    e.RequestInformation.ExtendedErrorInformation.ErrorCode == TableErrorCodeStrings.EntityAlreadyExists || 
+                    e.RequestInformation.ExtendedErrorInformation.ErrorCode == TableErrorCodeStrings.UpdateConditionNotSatisfied ||
+                    e.RequestInformation.ExtendedErrorInformation.ErrorCode == TableErrorCodeStrings.EntityAlreadyExists ||
                     e.RequestInformation.ExtendedErrorInformation.ErrorCode == TableErrorCodeStrings.EntityNotFound)
                 {
+                }
+                finally
+                {
+                    entity.ETag = null;
                 }
             }
         }


### PR DESCRIPTION
Sometimes errors like this are happened - https://lkeslacknotifications.blob.core.windows.net/slack-notifications-full-messages-2018-11/2018-11-02T21-19-30.6932543.90.txt. Since there is not Etag specified in the ```WalletRepository``` of the Balances service:

https://github.com/LykkeCity/Lykke.Service.Balances/blob/dev/src/Lykke.Service.Balances.AzureRepositories/WalletsRepository.cs#L33 -> https://github.com/LykkeCity/Lykke.Service.Balances/blob/master/src/Lykke.Service.Balances.AzureRepositories/WalletEntity.cs#L22

The only way why Etag might be not null, is retry of the ```InsertOrReplace``` method by the ```RetryOnFailureAzureTableStorageDecorator```. So, we have to reset Etag value after each try.